### PR TITLE
added matrix commands

### DIFF
--- a/shortex.sty
+++ b/shortex.sty
@@ -216,12 +216,19 @@
 \newcommand{\boundary}{\partial}
 
 
-%%%%%%%%%%%%%%%
-%%% Vectors %%%
-%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% Vectors & Matrices %%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%
 \newcommand{\bone}{\mathbf{1}}
 \newcommand{\bzero}{\mathbf{0}}
 \newcommand{\bell}{\mathbf{\ell}}
+\newcommand{\bpmat}{\begin{pmatrix}}
+\newcommand{\epmat}{\end{pmatrix}}
+\newcommand{\bbmat}{\begin{bmatrix}}
+\newcommand{\ebmat}{\end{bmatrix}}
+\newcommand{\bmat}{\begin{matrix}}
+\newcommand{\emat}{\end{matrix}}
+
 
 
 %%%%%%%%%%%%%%%%%%
@@ -474,8 +481,6 @@
 %%%%%%%%%%%%%%%%%
 \newcommand{\eps}{\epsilon}
 \newcommand{\veps}{\varepsilon}
-\newcommand{\bmat}{\begin{pmatrix}}
-\newcommand{\emat}{\end{pmatrix}}
 \newcommand{\bitems}{\begin{itemize}}
 \newcommand{\eitems}{\end{itemize}}
 \newcommand{\benum}{\begin{enumerate}}


### PR DESCRIPTION
Changed matrix typesetting to be more consistent:
- `bpmat / epmat` for parentheses matrices
- `bbmat / ebmat` for bracket matrices
- `bmat / emat` for matrices without surrounding marks

Closes #18