### PR TITLE
change `d` to `\dee` in `\dder`

### DIFF
--- a/shortex.sty
+++ b/shortex.sty
@@ -454,7 +454,7 @@
 \newcommand{\grad}{\nabla}
 
 \newcommand{\der}[2]{\ensuremath{\frac{\dee #1}{\dee #2}}}
-\newcommand{\dder}[2]{\ensuremath{\frac{d^2 #1}{d #2^2}}}
+\newcommand{\dder}[2]{\ensuremath{\frac{\dee^2 #1}{\dee #2^2}}}
 \newcommand{\D}[2]{\ensuremath{\frac{\partial #1}{\partial #2}}}
 \newcommand{\DD}[2]{\ensuremath{\frac{\partial^2 #1}{\partial #2^2}}}
 \newcommand{\Di}[2]{\ensuremath{\frac{\partial^i #1}{\partial #2^i}}}


### PR DESCRIPTION
Hi! The 2nd derivative command `\dder` was using a `d` instead of a proper `\dee`, as in the case of the 1st derivative `\der`. This PR fixes this. 